### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/cmd/prHistory.go
+++ b/cmd/prHistory.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -52,11 +52,16 @@ var prHistoryCmd = &cobra.Command{
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 		defer stop()
 
+		ghClient, err := newGithubClient(ctx)
+		if err != nil {
+			return err
+		}
+
 		query := &util.PullRequestQuery{
 			Org:     orgName,
 			Repo:    repoName,
 			DevMode: devMode,
-			Client:  util.NewGithubClient(ctx, githubToken()),
+			Client:  ghClient,
 		}
 
 		prStats := &stats.Stats{

--- a/cmd/pullRequests.go
+++ b/cmd/pullRequests.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -57,11 +57,16 @@ func newPullRequestsCommand() *cobra.Command {
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 			defer stop()
 
+			ghClient, err := newGithubClient(ctx)
+			if err != nil {
+				return err
+			}
+
 			query := &util.PullRequestQuery{
 				Org:     orgName,
 				Repo:    repoName,
 				DevMode: devMode,
-				Client:  util.NewGithubClient(ctx, githubToken()),
+				Client:  ghClient,
 			}
 
 			all := stats.Bucket{
@@ -88,7 +93,7 @@ func newPullRequestsCommand() *cobra.Command {
 				EarliestDate: earliestDate,
 				Buckets:      []*stats.Bucket{&all},
 			}
-			err := theStats.Populate(ctx)
+			err = theStats.Populate(ctx)
 			if err != nil {
 				return errors.Wrap(err, "could not generate stats")
 			}

--- a/cmd/reviewers.go
+++ b/cmd/reviewers.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -55,11 +55,16 @@ var reviewersCmd = &cobra.Command{
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 		defer stop()
 
+		ghClient, err := newGithubClient(ctx)
+		if err != nil {
+			return err
+		}
+
 		query := &util.PullRequestQuery{
 			Org:     orgName,
 			Repo:    repoName,
 			DevMode: devMode,
-			Client:  util.NewGithubClient(ctx, githubToken()),
+			Client:  ghClient,
 		}
 
 		var earliestDate time.Time
@@ -72,7 +77,7 @@ var reviewersCmd = &cobra.Command{
 			EarliestDate: earliestDate,
 		}
 
-		err := query.IteratePullRequests(ctx, reviewerStats.ProcessOne)
+		err = query.IteratePullRequests(ctx, reviewerStats.ProcessOne)
 		if err != nil {
 			return errors.Wrap(err, "failed to retrieve pull request details")
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,16 +16,23 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
+	"github.com/dhellmann/gh-review-stats/util"
 	"github.com/spf13/cobra"
 
+	"github.com/google/go-github/v45/github"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 )
 
-const githubTokenConfigOptionName = "github.token"
+const (
+	githubTokenConfigOptionName               = "github.token"
+	githubEnterpriseBaseURLConfigOptionName   = "github.enterprise.base-url"
+	githubEnterpriseUploadURLConfigOptionName = "github.enterprise.upload-url"
+)
 
 var cfgFile string
 
@@ -54,6 +61,15 @@ func githubToken() string {
 	return viper.GetString(githubTokenConfigOptionName)
 }
 
+func newGithubClient(ctx context.Context) (*github.Client, error) {
+	return util.NewGithubClient(
+		ctx,
+		githubToken(),
+		viper.GetString(githubEnterpriseBaseURLConfigOptionName),
+		viper.GetString(githubEnterpriseUploadURLConfigOptionName),
+	)
+}
+
 func addHistoryArgs(theCommand *cobra.Command) {
 	theCommand.PersistentFlags().StringVarP(&orgName, "org", "o", "",
 		"github org")
@@ -71,6 +87,8 @@ func init() {
 	// will be global for your application.
 
 	viper.SetDefault(githubTokenConfigOptionName, "")
+	viper.SetDefault(githubEnterpriseBaseURLConfigOptionName, "")
+	viper.SetDefault(githubEnterpriseUploadURLConfigOptionName, "")
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "",
 		"config file (default is $HOME/.gh-review-stats.yml)")

--- a/util/github.go
+++ b/util/github.go
@@ -9,10 +9,19 @@ import (
 
 // NewGithubClient creates a client for communicating with the GitHub
 // API using the provided token.
-func NewGithubClient(ctx context.Context, token string) *github.Client {
+func NewGithubClient(ctx context.Context, token, enterpriseBaseURL, enterpriseUploadURL string) (*github.Client, error) {
 	tokenSource := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
 	oauthClient := oauth2.NewClient(ctx, tokenSource)
-	return github.NewClient(oauthClient)
+
+	if enterpriseBaseURL != "" {
+		// If upload url is unset then we should set it to base URL
+		if enterpriseUploadURL == "" {
+			enterpriseUploadURL = enterpriseBaseURL
+		}
+		return github.NewEnterpriseClient(enterpriseBaseURL, enterpriseUploadURL, oauthClient)
+	}
+
+	return github.NewClient(oauthClient), nil
 }


### PR DESCRIPTION
Add config options for github.enterprise.(base-url, upload-url). If base-url is set then we initialize a GH enterprise client using these parameters.